### PR TITLE
fix: set Veloren log level based on cmd line arg

### DIFF
--- a/client/src/cli/mod.rs
+++ b/client/src/cli/mod.rs
@@ -58,10 +58,10 @@ async fn process_arguments(mut state: &mut SavedState, cmd: CmdLine) -> Result<(
         // CLI
         Some(action) => match action {
             Action::Update => update(&mut state, true).await?,
-            Action::Start => start(&mut state).await?,
+            Action::Start => start(&mut state, cmd.verbose).await?,
             Action::Run => {
                 update(&mut state, false).await?;
-                start(&mut state).await?
+                start(&mut state, cmd.verbose).await?
             },
         },
         // GUI
@@ -122,10 +122,13 @@ async fn download(profile: Profile) -> Result<()> {
     Ok(())
 }
 
-async fn start(state: &mut SavedState) -> Result<()> {
+async fn start(state: &mut SavedState, verbosity: i32) -> Result<()> {
     log::info!("Starting...");
-    let mut stream =
-        crate::io::stream_process(Profile::start(state.active_profile.clone())).boxed();
+    let mut stream = crate::io::stream_process(Profile::start(
+        state.active_profile.clone(),
+        verbosity,
+    ))
+    .boxed();
 
     while let Some(progress) = stream.next().await {
         match progress {

--- a/client/src/cli/parse.rs
+++ b/client/src/cli/parse.rs
@@ -8,8 +8,7 @@ use clap::{crate_authors, crate_version, Clap};
 pub struct CmdLine {
     #[clap(subcommand)]
     pub action: Option<Action>,
-    /// Set the logging verbosity for Veloren (v = INFO, vv = DEBUG, vvv =
-    /// TRACE)
+    /// Set the logging verbosity for Veloren (v = DEBUG, vv = TRACE)
     #[clap(short, long, parse(from_occurrences), global = true)]
     pub verbose: i32,
     /// Set the logging verbosity for Airshipper (d = DEBUG, dd = TRACE)

--- a/client/src/gui/mod.rs
+++ b/client/src/gui/mod.rs
@@ -47,18 +47,20 @@ pub struct Airshipper {
     /// Other unrelated state
     play_button_state: button::State,
     download_progress: Option<net::Progress>,
+    cmd: CmdLine,
 
     needs_save: bool,
     saving: bool,
 }
 
-impl Default for Airshipper {
-    fn default() -> Self {
+impl Airshipper {
+    pub fn new(cmd: CmdLine) -> Self {
         Self {
             state: LauncherState::LoadingSave,
             saveable_state: SavedState::empty(),
             play_button_state: Default::default(),
             download_progress: None,
+            cmd,
 
             needs_save: false,
             saving: false,
@@ -111,9 +113,9 @@ impl Application for Airshipper {
     type Message = Message;
     type Flags = CmdLine;
 
-    fn new(_flags: CmdLine) -> (Self, Command<Message>) {
+    fn new(flags: CmdLine) -> (Self, Command<Message>) {
         (
-            Airshipper::default(),
+            Airshipper::new(flags),
             Command::perform(SavedState::load(), Message::Loaded),
         )
     }

--- a/client/src/gui/update.rs
+++ b/client/src/gui/update.rs
@@ -90,6 +90,7 @@ pub fn handle_message(
             LauncherState::ReadyToPlay => {
                 airship.state = LauncherState::Playing(Profile::start(
                     airship.saveable_state.active_profile.clone(),
+                    airship.cmd.verbose,
                 ));
             },
             LauncherState::Error(_) => {

--- a/client/src/profiles.rs
+++ b/client/src/profiles.rs
@@ -1,7 +1,7 @@
 use crate::{consts, fs, net, CommandBuilder, Result};
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, ffi::OsString, path::PathBuf};
 
 /// Represents a version with channel, name and path.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,17 +65,24 @@ impl Profile {
     }
 
     // TODO: add possibility to start the server too
-    pub fn start(profile: Profile) -> CommandBuilder {
+    pub fn start(profile: Profile, verbosity: i32) -> CommandBuilder {
         let mut envs = HashMap::new();
         let profile_dir = profile.directory.clone().into_os_string();
         let saves_dir = profile.directory.join("saves").into_os_string();
         let logs_dir = profile.directory.join("logs").into_os_string();
         let screenshot_dir = profile.directory.join("screenshots").into_os_string();
+        let verbosity = match verbosity {
+            0 => OsString::from("info"),
+            1 => OsString::from("debug"),
+            _ => OsString::from("trace"),
+        };
+        log::error!("{}", verbosity.to_str().unwrap());
 
         envs.insert("VOXYGEN_CONFIG", &profile_dir);
         envs.insert("VOXYGEN_LOGS", &logs_dir);
         envs.insert("VOXYGEN_SCREENSHOT", &screenshot_dir);
         envs.insert("VELOREN_SAVES_DIR", &saves_dir);
+        envs.insert("RUST_LOG", &verbosity);
 
         log::debug!("Launching {}", profile.voxygen_path().display());
         log::debug!("CWD: {:?}", profile.directory);


### PR DESCRIPTION
Passing `-v` will now control Veloren logging level. Type `airshipper -h` for more info.