### PR TITLE
Improve font rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+- improved font rendering
+
 ## Fixed
 
 ## [0.4.1] - 2020-11-27

--- a/client/src/assets.rs
+++ b/client/src/assets.rs
@@ -1,4 +1,14 @@
 pub const FONT: &[u8] =
     include_bytes!("../assets/haxrcorp_4089_cyrillic_altgr_extended.ttf");
+// haxcorp 4089 is designed to be used at 12px without antialiasing, with integer scaling,
+// so that the glyph's vector will rasterize and align with the physical pixels for crisp font edges when displayed on digital displays.
+const BASE_FONT_SIZE: u16 = 12;
+// 12px is generally too small for accessibility purposes.
+// ~16px is minimum on 96ppi (pixels per inch) display.
+// pub const FONT_SIZE_1: u16 = BASE_FONT_SIZE * 1; // 12
+pub const FONT_SIZE_2: u16 = BASE_FONT_SIZE * 2; // 24
+pub const FONT_SIZE_3: u16 = BASE_FONT_SIZE * 3; // 36
+// pub const FONT_SIZE_4: u16 = BASE_FONT_SIZE * 4; // 48
+// pub const FONT_SIZE_5: u16 = BASE_FONT_SIZE * 5; // 60
 pub const VELOREN_LOGO: &[u8] = include_bytes!("../assets/veloren-logo.png");
 pub const VELOREN_ICON: &[u8] = include_bytes!("../assets/logo.ico");

--- a/client/src/gui/components/changelog.rs
+++ b/client/src/gui/components/changelog.rs
@@ -1,7 +1,6 @@
-use crate::{consts, gui::views::default::DefaultViewMessage, net, Result};
+use crate::{assets::FONT_SIZE_2, consts, gui::views::default::DefaultViewMessage, net, Result};
 use iced::{scrollable, Element};
 use serde::{Deserialize, Serialize};
-
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct Changelog {
     pub text: String,
@@ -54,7 +53,7 @@ impl Changelog {
             .height(Length::Fill)
             .padding(15)
             .spacing(20)
-            .push(Text::new(self.text.clone()).size(18))
+            .push(Text::new(self.text.clone()).size(FONT_SIZE_2))
             .into()
     }
 }

--- a/client/src/gui/components/news.rs
+++ b/client/src/gui/components/news.rs
@@ -1,4 +1,5 @@
 use crate::{
+    assets::{FONT_SIZE_2, FONT_SIZE_3},
     consts,
     gui::views::default::{DefaultViewMessage, Interaction},
     net, Result,
@@ -85,8 +86,8 @@ impl Post {
         use iced::{Column, Text};
 
         Column::new()
-            .push(Text::new(&self.title).size(20))
-            .push(Text::new(&self.description).size(16))
+            .push(Text::new(&self.title).size(FONT_SIZE_3))
+            .push(Text::new(&self.description).size(FONT_SIZE_2))
             .push(secondary_button(
                 &mut self.btn_state,
                 "Read More",

--- a/client/src/gui/views/default.rs
+++ b/client/src/gui/views/default.rs
@@ -1,5 +1,6 @@
 use super::Action;
 use crate::{
+    assets::{FONT_SIZE_2, FONT_SIZE_3},
     cli::CmdLine,
     gui::{
         components::{Changelog, News},
@@ -178,7 +179,7 @@ impl DefaultView {
             State::Playing(..) => "Much fun playing!".to_string(),
             State::Retry => "Error occured. Give it a retry.".to_string(),
         };
-        let download_speed = Text::new(&download_text).size(16);
+        let download_speed = Text::new(&download_text).size(FONT_SIZE_2);
         let download_progressbar =
             ProgressBar::new(0.0..=100.0, download_progress).style(style::Progress);
         let download = Column::new()
@@ -477,7 +478,7 @@ pub fn primary_button(
     let btn: Element<Interaction> = Button::new(
         state,
         Text::new(label)
-            .size(30)
+            .size(FONT_SIZE_3)
             .height(Length::Fill)
             .horizontal_alignment(HorizontalAlignment::Center)
             .vertical_alignment(VerticalAlignment::Center),
@@ -500,7 +501,7 @@ pub fn secondary_button(
     let btn: Element<Interaction> = Button::new(
         state,
         Text::new(label)
-            .size(16)
+            .size(FONT_SIZE_2)
             .horizontal_alignment(HorizontalAlignment::Center)
             .vertical_alignment(VerticalAlignment::Center),
     )

--- a/client/src/gui/views/update.rs
+++ b/client/src/gui/views/update.rs
@@ -61,7 +61,7 @@ impl UpdateView {
                         Button::new(
                             skip_button_state,
                             Text::new("Skip")
-                                .size(30)
+                                .size(FONT_SIZE_3)
                                 .height(Length::Fill)
                                 .horizontal_alignment(HorizontalAlignment::Center)
                                 .vertical_alignment(VerticalAlignment::Center),
@@ -74,7 +74,7 @@ impl UpdateView {
                         Button::new(
                             update_button_state,
                             Text::new("Update")
-                                .size(30)
+                                .size(FONT_SIZE_3)
                                 .height(Length::Fill)
                                 .width(Length::Units(90))
                                 .horizontal_alignment(HorizontalAlignment::Center)


### PR DESCRIPTION
Hi

haxcorp 4089 is designed to be used at 12px without anti-aliasing, with integer scaling,
so that the glyph's vector will rasterize and align with the physical pixels for sharp font edges when displayed on digital displays.

But 12px is generally too small for accessibility purposes, so 24 is the minimum size that we can use on 96ppi (pixels per inch) displays.

Here is a comparison screenshot:

Make sure to view the image at full 100% zoom so the browser does not mangle the scaling with bilinear scaling artifacts.

![font-rendering](https://user-images.githubusercontent.com/323398/100874802-108e1e00-34e0-11eb-9e41-fb6a8d086e63.png)

https://user-images.githubusercontent.com/323398/100874802-108e1e00-34e0-11eb-9e41-fb6a8d086e63.png

![Screenshot from 2020-12-02 19-44-06](https://user-images.githubusercontent.com/323398/100876581-88f5de80-34e2-11eb-8bda-a648299319ce.png)

https://user-images.githubusercontent.com/323398/100876581-88f5de80-34e2-11eb-8bda-a648299319ce.png

- Lobster