### PR TITLE
fix glibc missing

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -116,6 +116,13 @@ jobs:
           toolchain: ${{ steps.tool.outputs.rust_toolchain }}
           override: true
 
+      # Avoid missing glibc
+      - name: Enable static CRT linkage
+        run: |
+          mkdir .cargo
+          echo '[target.x86_64-pc-windows-msvc]' >> .cargo/config
+          echo 'rustflags = ["-Ctarget-feature=+crt-static"]' >> .cargo/config
+
       # Build
       - name: Build
         run: cargo build --bin airshipper --release --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved font rendering [#104](https://github.com/Songtronix/Airshipper/pull/104)
 - Fix os error 50 (Veloren can't be started) [#106](https://github.com/Songtronix/Airshipper/pull/106)
+- missing glibc [#111](https://github.com/Songtronix/Airshipper/pull/111)
 
 ## [0.4.1] - 2020-11-27
 


### PR DESCRIPTION
Some distros have outdated glibc so airshipper doesn't work. Now it will be statically compiled which doesn't guarantee it to work but likely should.

# Downside

It increases the binary size to 15MB.