### PR TITLE
CI: Build server image

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,62 @@
+# This workflow creates the airshipper server image
+name: Server Image
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'staging'
+    tags:
+      - 'v*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Docker meta
+        id: meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/songtronix/airshipper
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=semver,pattern={{version}},priority=100
+            type=ref,event=branch,priority=200
+            type=sha,priority=300
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - uses: docker/build-push-action@v2
+        id: docker_build
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: server/
+          file: server/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Automates the creation of the server docker image. Tags it based on branch name or git tag.

**Note**: Does not make these images public by default!