### PR TITLE
Windows fixes for older versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "clap",
+ "colored",
  "derive_more",
  "dirs-next",
  "fern",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,6 +1751,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3258,6 +3274,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3268,17 +3285,35 @@ dependencies = [
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite 0.2.0",
+ "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-rustls",
  "tokio-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72b84d47e8ec5a4f2872e8262b8f8256c5be1c938a7d6d3a867a3ba8f722f74"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3412,6 +3447,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
+dependencies = [
+ "base64 0.12.3",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
 name = "rusttype"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3478,6 +3526,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -3753,6 +3811,12 @@ dependencies = [
  "redox_syscall",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spirv_cross"
@@ -4128,6 +4192,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
+dependencies = [
+ "futures-core",
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-tls"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4351,6 +4427,12 @@ dependencies = [
  "generic-array 0.14.4",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -4667,6 +4749,25 @@ checksum = "dda38f4e5ca63eda02c059d243aa25b5f35ab98451e518c51612cd0f1bd19a47"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -31,7 +31,7 @@ fern = { version = "0.6.0", features = ["colored"] }
 chrono = "0.4.19"
 log = "0.4.11"
 # Networking
-reqwest = "0.10.8"
+reqwest = { version = "0.10.8", default-features = false, features = ["rustls-tls"] }
 # Parsing
 strip_markdown = "0.2.0"
 html2text = "0.2.1"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -28,6 +28,7 @@ iced = { git = "https://github.com/hecrj/iced.git", default-features = false, fe
 iced_native = { git = "https://github.com/hecrj/iced.git", default-features = false, rev = "62295f5" }
 # Logging
 fern = { version = "0.6.0", features = ["colored"] }
+colored = "1.5"
 chrono = "0.4.19"
 log = "0.4.11"
 # Networking

--- a/client/src/logger.rs
+++ b/client/src/logger.rs
@@ -63,6 +63,14 @@ pub fn log(level: LevelFilter) {
         })
         .chain(fern::log_file(&fs::log_file()).expect("Failed to setup log file!"));
 
+    #[allow(unused_mut)]
+    let mut color = colored::control::SHOULD_COLORIZE.should_colorize();
+
+    #[cfg(windows)]
+    {
+        color &= crate::windows::color_support();
+    }
+
     let mut stdout_cfg = fern::Dispatch::new()
         .level(level)
         .level_for("wgpu_core::device", LevelFilter::Error);
@@ -76,7 +84,11 @@ pub fn log(level: LevelFilter) {
                     .line()
                     .map(|x| x.to_string())
                     .unwrap_or_else(|| "X".to_string()),
-                colors.color(record.level()),
+                if color {
+                    colors.color(record.level()).to_string()
+                } else {
+                    record.level().to_string()
+                },
                 message
             ))
         });
@@ -84,7 +96,11 @@ pub fn log(level: LevelFilter) {
         stdout_cfg = stdout_cfg.format(move |out, message, record| {
             out.finish(format_args!(
                 "[{}] {}",
-                colors.color(record.level()),
+                if color {
+                    colors.color(record.level()).to_string()
+                } else {
+                    record.level().to_string()
+                },
                 message
             ))
         });

--- a/client/src/net/client.rs
+++ b/client/src/net/client.rs
@@ -9,8 +9,10 @@ lazy_static::lazy_static! {
     pub static ref WEB_CLIENT: reqwest::Client = {
         reqwest::Client::builder()
             .user_agent(USER_AGENT)
+            .use_rustls_tls()
             .timeout(std::time::Duration::from_secs(10))
-            .build().expect("FATAL: Failed to build reqwest client!")
+            .build()
+            .expect("FATAL: Failed to build reqwest client!")
     };
 }
 

--- a/client/src/windows.rs
+++ b/client/src/windows.rs
@@ -11,9 +11,13 @@ use winapi::{
     ctypes::c_int,
     shared::minwindef::DWORD,
     um::{
+        consoleapi::GetConsoleMode,
+        handleapi::INVALID_HANDLE_VALUE,
+        processenv::GetStdHandle,
         processthreadsapi::GetCurrentProcessId,
         shellapi::ShellExecuteW,
-        wincon::GetConsoleWindow,
+        winbase::STD_OUTPUT_HANDLE,
+        wincon::{GetConsoleWindow, ENABLE_VIRTUAL_TERMINAL_PROCESSING},
         winuser::{GetWindowThreadProcessId, ShowWindow, SW_HIDE, SW_SHOW},
     },
 };
@@ -161,4 +165,30 @@ fn started_from_console() -> bool {
 
         process_id != parent_id
     }
+}
+
+/// Determines whether the console supports [ANSI escape code](https://en.wikipedia.org/wiki/ANSI_escape_code)
+pub fn color_support() -> bool {
+    let mut color = false;
+
+    // Safety:
+    // GetStdHandle is checked for errors and for null handles.
+    // GetConsoleMode the handle passed must have the GENERIC_READ access right
+    // this always the case for handles returned by
+    // GetStdHandle(STD_OUTPUT_HANDLE) unless the program has changed the access
+    // rights, we don't so it's safe. The second argument lpMode must be a valid
+    // pointer for the duration of the call guaranteed by the rust borrow
+    // checker since mode lives until the end of the block.
+    unsafe {
+        let handle = GetStdHandle(STD_OUTPUT_HANDLE);
+        if handle != INVALID_HANDLE_VALUE && !handle.is_null() {
+            let mut mode: DWORD = 0;
+            GetConsoleMode(handle, &mut mode);
+
+            color = mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING
+                == ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+        }
+    }
+
+    color
 }


### PR DESCRIPTION
Uses rustls instead of the default `native-tls` because on windows 8.1 and older it would use `schannel` (windows ssl library) which only supports until TLSv1.0 and that is no longer accepted by the veloren server.

Also adds a check for whether or not coloring the console output is wanted. The `colored` was already transitively depended by fern so there are new dependencies here (I made sure to line up the versions). There's also a bit of unsafe to call a windows api to get whether or not ansi ascii codes are supported I have wrote about why it's safe in the comment preceding the unsafe block