### PR TITLE
Fix web client timeout

### DIFF
--- a/client/src/net/client.rs
+++ b/client/src/net/client.rs
@@ -10,7 +10,7 @@ lazy_static::lazy_static! {
         reqwest::Client::builder()
             .user_agent(USER_AGENT)
             .use_rustls_tls()
-            .timeout(std::time::Duration::from_secs(10))
+            .connect_timeout(std::time::Duration::from_secs(10))
             .build()
             .expect("FATAL: Failed to build reqwest client!")
     };


### PR DESCRIPTION
https://github.com/Songtronix/Airshipper/pull/160 resulted in downloads being aborted after 10s.
Using `connect_timeout` instead which seems to be what we actually want here.