### PR TITLE
chore: prepare the move to the veloren organisation

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-patreon: songtronix

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            ghcr.io/songtronix/airshipper
+            ghcr.io/veloren/airshipper
           # generate Docker tags based on the following events/attributes
           tags: |
             type=semver,pattern={{version}},priority=100

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at report@songtronix.com. All
+reported by contacting the project team at report@veloren.net. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -2,9 +2,9 @@
 
 For *binary* packages the following urls can be used (replace `v*.*.*` with the latest version):
 
-Windows: `https://github.com/songtronix/airshipper/releases/v*.*.*/download/airshipper-windows.msi`
-MacOS: `https://github.com/songtronix/airshipper/releases/v*.*.*/download/airshipper-macos.tar.gz`
-Linux: `https://github.com/songtronix/airshipper/releases/v*.*.*/download/airshipper-linux.tar.gz`
+Windows: `https://github.com/veloren/airshipper/releases/v*.*.*/download/airshipper-windows.msi`
+MacOS: `https://github.com/veloren/airshipper/releases/v*.*.*/download/airshipper-macos.tar.gz`
+Linux: `https://github.com/veloren/airshipper/releases/v*.*.*/download/airshipper-linux.tar.gz`
 
 Replace `v*.*.*` with `latest` to always get the latest release.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Airshipper
 
-[![GitHub release)](https://img.shields.io/github/v/release/songtronix/airshipper?include_prereleases)](https://github.com/Songtronix/Airshipper/releases) [![License](https://img.shields.io/github/license/songtronix/airshipper?color=blue)](https://github.com/Songtronix/Airshipper/blob/master/LICENSE) [![Discord](https://img.shields.io/discord/449602562165833758?label=discord)](https://discord.gg/rvbW3Z4) [![AUR version](https://img.shields.io/aur/version/airshipper?label=AUR)](https://aur.archlinux.org/packages/airshipper/) [![Custom badge](https://img.shields.io/endpoint?color=orange&label=Support%20me&url=https%3A%2F%2Fmoshef9.wixsite.com%2Fpatreon-badge%2F_functions%2Fbadge%2F%3Fusername%3Dsongtronix)](https://www.patreon.com/songtronix)
+[![GitHub release)](https://img.shields.io/github/v/release/veloren/airshipper?include_prereleases)](https://github.com/veloren/Airshipper/releases) [![License](https://img.shields.io/github/license/veloren/airshipper?color=blue)](https://github.com/veloren/Airshipper/blob/master/LICENSE) [![Discord](https://img.shields.io/discord/449602562165833758?label=discord)](https://discord.gg/rvbW3Z4) [![AUR version](https://img.shields.io/aur/version/airshipper?label=AUR)](https://aur.archlinux.org/packages/airshipper/)
 
 A cross-platform Veloren launcher.
 
-![Airshipper](https://www.songtronix.com/airshipper-0.4.0.gif)
+![Airshipper](https://camo.githubusercontent.com/71dfc8bb095129c57a7d2c29ff7d50bba4c91e67fef84c2e6ef93be7efb1e02a/68747470733a2f2f7777772e736f6e6774726f6e69782e636f6d2f616972736869707065722d302e342e302e676966)
 
 ## Features
 
@@ -14,14 +14,12 @@ A cross-platform Veloren launcher.
 
 ## Download
 
-For all download options visit my website: [www.songtronix.com](https://www.songtronix.com)
-
 **NOTE:** Airshipper cannot be considered stable yet.
 
 #### Compile from source
 
 ```bash
-git clone https://github.com/Songtronix/Airshipper.git
+git clone https://github.com/veloren/Airshipper.git
 cd Airshipper
 cargo run --release
 ```

--- a/client/src/windows.rs
+++ b/client/src/windows.rs
@@ -23,6 +23,7 @@ use winapi::{
 };
 
 pub fn query() -> Result<Option<Release>> {
+    // TODO: Has to be adjusted.
     let releases = self_update::backends::github::ReleaseList::configure()
         .repo_owner("songtronix")
         .repo_name("airshipper")

--- a/server/build_server.ps1
+++ b/server/build_server.ps1
@@ -4,7 +4,7 @@ if (!($tag = Read-Host "Docker Image Tag [$default]")) { $tag = $default }
 
 Copy-Item Cargo.lock server/Cargo.lock
 sleep 1
-docker build server/ -f server/Dockerfile -t docker.pkg.github.com/songtronix/airshipper/airshipper:$tag
+docker build server/ -f server/Dockerfile -t docker.pkg.github.com/veloren/airshipper/airshipper:$tag
 sleep 1
 Remove-Item server/Cargo.lock -ErrorAction Ignore
 sleep 1

--- a/server/build_server.sh
+++ b/server/build_server.sh
@@ -2,7 +2,7 @@
 # NOTE: EXECUTE THIS FROM THE WORKSPACE ROOT ONLY
 cp Cargo.lock server/Cargo.lock
 sleep 1
-sudo docker build server/ -f server/Dockerfile -t docker.pkg.github.com/songtronix/airshipper/airshipper:master
+sudo docker build server/ -f server/Dockerfile -t docker.pkg.github.com/veloren/airshipper/airshipper:master
 sleep 1
 rm server/Cargo.lock
 sleep 1

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   airshipper:
     container_name: Airshipper
     restart: always
-    image: docker.pkg.github.com/songtronix/airshipper/airshipper:master
+    image: docker.pkg.github.com/veloren/airshipper/airshipper:master
     volumes:
       - "./data:/opt/app/data"
       - "./data/nightly:/opt/app/nightly"

--- a/server/publish_server.ps1
+++ b/server/publish_server.ps1
@@ -3,4 +3,4 @@
 $default = "master"
 if (!($tag = Read-Host "Docker Image Tag [$default]")) { $tag = $default }
 
-docker push docker.pkg.github.com/songtronix/airshipper/airshipper:$tag
+docker push docker.pkg.github.com/veloren/airshipper/airshipper:$tag

--- a/server/publish_server.sh
+++ b/server/publish_server.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # NOTE: Run `build_server.sh` beforehand!
-sudo docker push docker.pkg.github.com/songtronix/airshipper/airshipper:master
+sudo docker push docker.pkg.github.com/veloren/airshipper/airshipper:master

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -41,7 +41,7 @@ impl<'r, 'o> Responder<'r, 'static> for ServerError {
                 resp.status(Status::InternalServerError);
                 let body = format!(
                     "We hit a serious error with your request to '{}'. Please report \
-                     this to @Songtronix#4790 on Discord!",
+                     this on our Discord!",
                     req.uri()
                 );
                 resp.sized_body(body.len(), Cursor::new(body));


### PR DESCRIPTION
Airshipper will be moved over to the Veloren Organisation on Github https://github.com/veloren and I will leave as a Core Developer. Please direct any further questions to the team at discord.

All package maintainers are advised to update their packages. However this should not break your package.
Github will automatically redirect all requests to the new repository.
https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/transferring-a-repository#whats-transferred-with-a-repository

Was a pleasure to work with you all.